### PR TITLE
Correct date of first ambassador to Haiti

### DIFF
--- a/articles/haiti.xml
+++ b/articles/haiti.xml
@@ -58,7 +58,7 @@
                         Embassy. <ref target="/departmenthistory/people/white-john-campbell">John
                             Campbell White</ref> was promoted to Ambassador Extraordinary and
                         Plenipotentiary and presented his credentials to the Government of Haiti on
-                        March 14, 1943.</p>
+                        April 14, 1943.</p>
                 </div>
             </div>
             <div type="appendix">


### PR DESCRIPTION
John Campbell White's [Department History page](https://history.state.gov/departmenthistory/people/white-john-campbell) lists him as having been promoted to Ambassador to Haiti on 1943-04-14 — the month listed in the Haiti article seems to be mistaken.